### PR TITLE
Allow to override password, but keep username (auth_cid/auth_pw)

### DIFF
--- a/plugins/managesieve/lib/Roundcube/rcube_sieve.php
+++ b/plugins/managesieve/lib/Roundcube/rcube_sieve.php
@@ -77,6 +77,8 @@ class rcube_sieve
         if (!empty($auth_cid)) {
             $authz    = $username;
             $username = $auth_cid;
+        }
+        if (!empty($auth_pw)) {
             $password = $auth_pw;
         }
 


### PR DESCRIPTION
There is a managesieve server from afterlogic, which allows to authenticate by providing a "master password" for any given username. This patch allows to use the auth_pw config option to make this work (auth_cid remains null)